### PR TITLE
Look for the readyci.yml file as defined in the projectPath instead of the codePath.

### DIFF
--- a/src/main/java/com/squarepolka/readyci/tasks/realci/ConfigurationLoad.java
+++ b/src/main/java/com/squarepolka/readyci/tasks/realci/ConfigurationLoad.java
@@ -26,7 +26,7 @@ public class ConfigurationLoad extends Task {
     @Override
     public void performTask(BuildEnvironment buildEnvironment) {
         File repoConfigurationFile = getRepoConfigurationFile(buildEnvironment);
-        if (null != repoConfigurationFile && repoConfigurationFile.exists()) {
+        if (repoConfigurationFile.exists()) {
             LOGGER.debug(String.format("Loading local repository configuration from %s", TASK_CONFIGURATION_FILE_NAME));
             ReadyCIConfiguration localConfiguration = ReadyCIConfiguration.readConfigurationFile(repoConfigurationFile);
             mergeLocalConfigWithBuildEnvironment(localConfiguration, buildEnvironment);
@@ -36,9 +36,8 @@ public class ConfigurationLoad extends Task {
     }
     
     private File getRepoConfigurationFile(BuildEnvironment buildEnvironment) {
-        String localConfigurationPath = String.format("%s/%s", buildEnvironment.codePath, TASK_CONFIGURATION_FILE_NAME);
-        File repoConfigurationFile = new File(localConfigurationPath);
-        return repoConfigurationFile;
+        String localConfigurationPath = String.format("%s/%s", buildEnvironment.projectPath, TASK_CONFIGURATION_FILE_NAME);
+        return new File(localConfigurationPath);
     }
 
     private void mergeLocalConfigWithBuildEnvironment(ReadyCIConfiguration localConfiguration, BuildEnvironment buildEnvironment) {


### PR DESCRIPTION
Look for the readyci.yml file from the projectPath provided as a command line argument to allow multiple readyci.yml files for monolith repositories.

If the projectPath is not defined, it falls back to the codePath