### PR TITLE
Enrich android play store upload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,11 @@
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>net.dongliu</groupId>
+            <artifactId>apk-parser</artifactId>
+            <version>2.6.5</version>
+        </dependency>
         <!-- Kotlin -->
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>

--- a/src/main/java/com/squarepolka/readyci/configuration/AndroidPropConstants.java
+++ b/src/main/java/com/squarepolka/readyci/configuration/AndroidPropConstants.java
@@ -8,7 +8,6 @@ public class AndroidPropConstants {
 
     public static final String BUILD_PROP_SCHEME = "scheme";
     public static final String BUILD_PROP_DEPLOY_TRACK = "deployTrack";
-    public static final String BUILD_PROP_PACKAGE_NAME = "packageName";
     public static final String BUILD_PROP_SERVICE_ACCOUNT_FILE = "playStoreAuthCert";
     public static final String BUILD_PROP_SERVICE_ACCOUNT_EMAIL = "playStoreEmail";
     public static final String BUILD_PROP_JAVA_KEYSTORE_PATH = "javaKeystorePath";

--- a/src/main/java/com/squarepolka/readyci/tasks/app/android/AndroidUploadStore.java
+++ b/src/main/java/com/squarepolka/readyci/tasks/app/android/AndroidUploadStore.java
@@ -105,13 +105,9 @@ public class AndroidUploadStore extends Task {
                             new Track().setReleases(
                                     Collections.singletonList(
                                             new TrackRelease()
-                                                    .setName("Alpha Release")
+                                                    .setName(apkMetadata.getVersionName())
                                                     .setVersionCodes(apkVersionCodes)
-                                                    .setStatus("completed")
-                                                    .setReleaseNotes(Collections.singletonList(
-                                                            new LocalizedText()
-                                                                    .setLanguage("en-AU")
-                                                                    .setText("This is an alpha release"))))));
+                                                    .setStatus("completed"))));
             Track updatedTrack = updateTrackRequest.execute();
             LOGGER.info("AndroidUploadStore: Track {} has been updated.", updatedTrack.getTrack());
 

--- a/src/main/java/com/squarepolka/readyci/tasks/app/android/AndroidUploadStore.java
+++ b/src/main/java/com/squarepolka/readyci/tasks/app/android/AndroidUploadStore.java
@@ -9,13 +9,17 @@ import com.squarepolka.readyci.taskrunner.BuildEnvironment;
 import com.squarepolka.readyci.taskrunner.TaskFailedException;
 import com.squarepolka.readyci.tasks.Task;
 import com.squarepolka.readyci.util.android.AndroidPublisherHelper;
+import com.squarepolka.readyci.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import net.dongliu.apk.parser.ApkFile;
+import net.dongliu.apk.parser.bean.ApkMeta;
 
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Collection;
 import java.util.List;
 
 import static com.squarepolka.readyci.configuration.AndroidPropConstants.*;
@@ -38,7 +42,6 @@ public class AndroidUploadStore extends Task {
         try {
 
             String deployTrack = buildEnvironment.getProperty(BUILD_PROP_DEPLOY_TRACK, "");
-            String packageName = buildEnvironment.getProperty(BUILD_PROP_PACKAGE_NAME, "");
             String playStoreEmail = buildEnvironment.getProperty(BUILD_PROP_SERVICE_ACCOUNT_EMAIL, "");
             String playStoreCert = buildEnvironment.getProperty(BUILD_PROP_SERVICE_ACCOUNT_FILE, "");
 
@@ -81,11 +84,12 @@ public class AndroidUploadStore extends Task {
             }
 
             File rawFile = files.iterator().next();
+            ApkMeta apkMetadata = new ApkFile(rawFile).getApkMeta();
 
             final AbstractInputStreamContent apkFile = new FileContent(AndroidPublisherHelper.MIME_TYPE_APK, rawFile);
             AndroidPublisher.Edits.Apks.Upload uploadRequest = edits
                     .apks()
-                    .upload(packageName, editId, apkFile);
+                    .upload(apkMetadata.getPackageName(), editId, apkFile);
 
             Apk apk = uploadRequest.execute();
             LOGGER.info("AndroidUploadStore: Version code {} has been uploaded", apk.getVersionCode());

--- a/src/main/java/com/squarepolka/readyci/tasks/app/android/AndroidUploadStore.java
+++ b/src/main/java/com/squarepolka/readyci/tasks/app/android/AndroidUploadStore.java
@@ -78,12 +78,24 @@ public class AndroidUploadStore extends Task {
             final String editId = edit.getId();
             LOGGER.info("AndroidUploadStore: Created edit with id: {}", editId);
 
-            Collection<File> files = Util.findAllByExtension(new File(buildEnvironment.getProjectPath()), ".apk");
-            if(files.size() > 1) {
-                throw new RuntimeException("Not set up to discern which is the correct apk");
+            Collection<File> unfilteredApks = Util.findAllByExtension(new File(buildEnvironment.getProjectPath()), ".apk");
+            List<File> filteredApks = new ArrayList<File>();
+            for(File apk : unfilteredApks) {
+                if(!absolutePath.contains("build/outputs") || 
+                    absolutePath.endsWith("aligned.apk") || 
+                    absolutePath.endsWith("signed.apk") || 
+                    absolutePath.endsWith("uninstrumented.apk")) {
+                    continue;
+                }
+
+                filteredApks.add(apk);
             }
 
-            File rawFile = files.iterator().next();
+            if(filteredApks.size() != 1) {
+                throw new RuntimeException("Either there's no APK, or too many APKs");
+            }
+
+            File rawFile = filteredApks.get(0);
             ApkMeta apkMetadata = new ApkFile(rawFile).getApkMeta();
 
             final AbstractInputStreamContent apkFile = new FileContent(AndroidPublisherHelper.MIME_TYPE_APK, rawFile);


### PR DESCRIPTION
Ok, so this might look a bit scary at first, but this PR represents 2 main changes to how we are uploading to the play store.
- Support productFlavors and custom apk names
- Derive version name rather than pass it in as a parameter

The second one is more interesting, because its not uncommon to have more than one apk in the project. To resolve this, we're trying to filter out APKs that we know are not appropriate for release, and if theres less or more than one remaining, we tell the project own to figure it out. 

The criteria by which were filtering are:
- Its not a child of the outputs file
- It contains contain signed/aligned/uninstrumented in the name (generally indicates its an intermediary file)
- Its not signed
- It is debuggable

If were OK with this logic, I'll extract it out into a util method so that hockeyapp can use them